### PR TITLE
Move landing page animations into external script

### DIFF
--- a/index.html
+++ b/index.html
@@ -1016,61 +1016,6 @@
         </div>
     </footer>
 
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const emberField = document.querySelector('#ember-field');
-            if (emberField) {
-                const emberCount = window.innerWidth < 768 ? 35 : 70;
-                for (let i = 0; i < emberCount; i++) {
-                    const ember = document.createElement('span');
-                    ember.style.left = `${Math.random() * 100}%`;
-                    ember.style.animationDelay = `${Math.random() * -24}s`;
-                    ember.style.animationDuration = `${12 + Math.random() * 14}s`;
-                    ember.style.opacity = `${0.3 + Math.random() * 0.6}`;
-                    const scale = 0.4 + Math.random() * 1.3;
-                    ember.style.transform = `scale(${scale})`;
-                    emberField.appendChild(ember);
-                }
-            }
-
-            const parallaxItems = document.querySelectorAll('[data-parallax]');
-            window.addEventListener('mousemove', (event) => {
-                const x = event.clientX / window.innerWidth - 0.5;
-                const y = event.clientY / window.innerHeight - 0.5;
-                parallaxItems.forEach((item) => {
-                    const intensity = parseFloat(item.dataset.parallax || '0');
-                    const translateX = x * intensity * -40;
-                    const translateY = y * intensity * -24;
-                    item.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
-                });
-            });
-
-            const observer = new IntersectionObserver((entries, obs) => {
-                entries.forEach((entry) => {
-                    if (entry.isIntersecting) {
-                        entry.target.classList.add('is-visible');
-                        obs.unobserve(entry.target);
-                    }
-                });
-            }, { threshold: 0.25 });
-
-            document.querySelectorAll('[data-animate]').forEach((element) => {
-                observer.observe(element);
-            });
-
-            const progressBar = document.querySelector('.scroll-progress-bar');
-            if (progressBar) {
-                const updateProgress = () => {
-                    const scrollTop = window.scrollY;
-                    const docHeight = document.body.scrollHeight - window.innerHeight;
-                    const progress = docHeight > 0 ? scrollTop / docHeight : 0;
-                    progressBar.style.transform = `scaleX(${progress})`;
-                };
-                updateProgress();
-                window.addEventListener('scroll', updateProgress);
-                window.addEventListener('resize', updateProgress);
-            }
-        });
-    </script>
+    <script src="/js/site.js" defer></script>
 </body>
 </html>

--- a/public/js/site.js
+++ b/public/js/site.js
@@ -1,0 +1,56 @@
+(function () {
+  document.addEventListener('DOMContentLoaded', () => {
+    const emberField = document.querySelector('#ember-field');
+    if (emberField) {
+      const emberCount = window.innerWidth < 768 ? 35 : 70;
+      for (let i = 0; i < emberCount; i += 1) {
+        const ember = document.createElement('span');
+        ember.style.left = `${Math.random() * 100}%`;
+        ember.style.animationDelay = `${Math.random() * -24}s`;
+        ember.style.animationDuration = `${12 + Math.random() * 14}s`;
+        ember.style.opacity = `${0.3 + Math.random() * 0.6}`;
+        const scale = 0.4 + Math.random() * 1.3;
+        ember.style.transform = `scale(${scale})`;
+        emberField.appendChild(ember);
+      }
+    }
+
+    const parallaxItems = document.querySelectorAll('[data-parallax]');
+    window.addEventListener('mousemove', (event) => {
+      const x = event.clientX / window.innerWidth - 0.5;
+      const y = event.clientY / window.innerHeight - 0.5;
+      parallaxItems.forEach((item) => {
+        const intensity = parseFloat(item.dataset.parallax || '0');
+        const translateX = x * intensity * -40;
+        const translateY = y * intensity * -24;
+        item.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
+      });
+    });
+
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          obs.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.25 });
+
+    document.querySelectorAll('[data-animate]').forEach((element) => {
+      observer.observe(element);
+    });
+
+    const progressBar = document.querySelector('.scroll-progress-bar');
+    if (progressBar) {
+      const updateProgress = () => {
+        const scrollTop = window.scrollY;
+        const docHeight = document.body.scrollHeight - window.innerHeight;
+        const progress = docHeight > 0 ? scrollTop / docHeight : 0;
+        progressBar.style.transform = `scaleX(${progress})`;
+      };
+      updateProgress();
+      window.addEventListener('scroll', updateProgress);
+      window.addEventListener('resize', updateProgress);
+    }
+  });
+})();

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 const indexPath = path.join(__dirname, 'index.html');
+const publicPath = path.join(__dirname, 'public');
 
 app.disable('x-powered-by');
 
@@ -29,6 +30,8 @@ app.use(
     crossOriginEmbedderPolicy: false,
   })
 );
+
+app.use('/js', express.static(path.join(publicPath, 'js')));
 
 function sendIndex(request, response, next) {
   response.setHeader('Cache-Control', 'no-store');


### PR DESCRIPTION
## Summary
- move the landing page interaction logic into a dedicated /js/site.js asset to avoid CSP inline-script violations
- expose the new JavaScript bundle through Express static middleware so Helmet can continue to enforce the existing CSP

## Testing
- npm start
- curl -I http://localhost:3000/js/site.js

------
https://chatgpt.com/codex/tasks/task_e_68d346765abc8320817674b461877276