### PR TITLE
Fix landing page visibility without inline script

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,12 +674,17 @@
         }
 
         [data-animate] {
+            opacity: 1;
+            transform: none;
+        }
+
+        .js [data-animate] {
             opacity: 0;
             transform: translateY(45px);
             transition: opacity 0.9s ease, transform 0.9s ease;
         }
 
-        [data-animate].is-visible {
+        .js [data-animate].is-visible {
             opacity: 1;
             transform: translateY(0);
         }
@@ -1016,61 +1021,6 @@
         </div>
     </footer>
 
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const emberField = document.querySelector('#ember-field');
-            if (emberField) {
-                const emberCount = window.innerWidth < 768 ? 35 : 70;
-                for (let i = 0; i < emberCount; i++) {
-                    const ember = document.createElement('span');
-                    ember.style.left = `${Math.random() * 100}%`;
-                    ember.style.animationDelay = `${Math.random() * -24}s`;
-                    ember.style.animationDuration = `${12 + Math.random() * 14}s`;
-                    ember.style.opacity = `${0.3 + Math.random() * 0.6}`;
-                    const scale = 0.4 + Math.random() * 1.3;
-                    ember.style.transform = `scale(${scale})`;
-                    emberField.appendChild(ember);
-                }
-            }
-
-            const parallaxItems = document.querySelectorAll('[data-parallax]');
-            window.addEventListener('mousemove', (event) => {
-                const x = event.clientX / window.innerWidth - 0.5;
-                const y = event.clientY / window.innerHeight - 0.5;
-                parallaxItems.forEach((item) => {
-                    const intensity = parseFloat(item.dataset.parallax || '0');
-                    const translateX = x * intensity * -40;
-                    const translateY = y * intensity * -24;
-                    item.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
-                });
-            });
-
-            const observer = new IntersectionObserver((entries, obs) => {
-                entries.forEach((entry) => {
-                    if (entry.isIntersecting) {
-                        entry.target.classList.add('is-visible');
-                        obs.unobserve(entry.target);
-                    }
-                });
-            }, { threshold: 0.25 });
-
-            document.querySelectorAll('[data-animate]').forEach((element) => {
-                observer.observe(element);
-            });
-
-            const progressBar = document.querySelector('.scroll-progress-bar');
-            if (progressBar) {
-                const updateProgress = () => {
-                    const scrollTop = window.scrollY;
-                    const docHeight = document.body.scrollHeight - window.innerHeight;
-                    const progress = docHeight > 0 ? scrollTop / docHeight : 0;
-                    progressBar.style.transform = `scaleX(${progress})`;
-                };
-                updateProgress();
-                window.addEventListener('scroll', updateProgress);
-                window.addEventListener('resize', updateProgress);
-            }
-        });
-    </script>
+    <script src="/js/site.js" defer></script>
 </body>
 </html>

--- a/public/js/site.js
+++ b/public/js/site.js
@@ -1,0 +1,73 @@
+(function () {
+  const root = document.documentElement;
+  if (root && !root.classList.contains('js')) {
+    root.classList.add('js');
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const emberField = document.querySelector('#ember-field');
+    if (emberField) {
+      const emberCount = window.innerWidth < 768 ? 35 : 70;
+      for (let i = 0; i < emberCount; i += 1) {
+        const ember = document.createElement('span');
+        ember.style.left = `${Math.random() * 100}%`;
+        ember.style.animationDelay = `${Math.random() * -24}s`;
+        ember.style.animationDuration = `${12 + Math.random() * 14}s`;
+        ember.style.opacity = `${0.3 + Math.random() * 0.6}`;
+        const scale = 0.4 + Math.random() * 1.3;
+        ember.style.transform = `scale(${scale})`;
+        emberField.appendChild(ember);
+      }
+    }
+
+    const parallaxItems = document.querySelectorAll('[data-parallax]');
+    if (parallaxItems.length > 0) {
+      const handleMouseMove = (event) => {
+        const x = event.clientX / window.innerWidth - 0.5;
+        const y = event.clientY / window.innerHeight - 0.5;
+        parallaxItems.forEach((item) => {
+          const intensity = parseFloat(item.dataset.parallax || '0');
+          const translateX = x * intensity * -40;
+          const translateY = y * intensity * -24;
+          item.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
+        });
+      };
+      window.addEventListener('mousemove', handleMouseMove);
+    }
+
+    const animatedElements = document.querySelectorAll('[data-animate]');
+    if (animatedElements.length > 0) {
+      if ('IntersectionObserver' in window) {
+        const observer = new IntersectionObserver((entries, obs) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('is-visible');
+              obs.unobserve(entry.target);
+            }
+          });
+        }, { threshold: 0.25 });
+
+        animatedElements.forEach((element) => {
+          observer.observe(element);
+        });
+      } else {
+        animatedElements.forEach((element) => {
+          element.classList.add('is-visible');
+        });
+      }
+    }
+
+    const progressBar = document.querySelector('.scroll-progress-bar');
+    if (progressBar) {
+      const updateProgress = () => {
+        const scrollTop = window.scrollY;
+        const docHeight = document.body.scrollHeight - window.innerHeight;
+        const progress = docHeight > 0 ? scrollTop / docHeight : 0;
+        progressBar.style.transform = `scaleX(${progress})`;
+      };
+      updateProgress();
+      window.addEventListener('scroll', updateProgress, { passive: true });
+      window.addEventListener('resize', updateProgress);
+    }
+  });
+})();

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 const indexPath = path.join(__dirname, 'index.html');
+const publicPath = path.join(__dirname, 'public');
 
 app.disable('x-powered-by');
 
@@ -29,6 +30,8 @@ app.use(
     crossOriginEmbedderPolicy: false,
   })
 );
+
+app.use('/js', express.static(path.join(publicPath, 'js')));
 
 function sendIndex(request, response, next) {
   response.setHeader('Cache-Control', 'no-store');


### PR DESCRIPTION
## Summary
- default the landing page sections to be visible unless the JavaScript controller enables animation classes
- add a runtime `.js` marker and IntersectionObserver fallback so sections reveal even when the observer API is unavailable

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d346765abc8320817674b461877276